### PR TITLE
Feat(policy-recommend): 정책 페이지 자동 제공 함수 추가

### DIFF
--- a/policy_recommend/url.js
+++ b/policy_recommend/url.js
@@ -1,0 +1,39 @@
+// 기관소식: 47 7100
+// 타기관소식: 2 282
+function get_url(boardSeq=47, menuSeq=7100, conSeq=466575){
+    // 1. <form> 엘리먼트를 동적으로 생성합니다.
+    const form = document.createElement('form');
+
+    // 2. Form의 속성을 설정합니다.
+    form.setAttribute('method', 'POST'); // 전송 방식: POST
+    form.setAttribute('action', 'https://www.liveinkorea.kr/portal/KOR/board/mlbs/boardView.do'); // 제출 URL
+    form.setAttribute('target', '_blank'); // 새 창(_blank)에서 열리도록 설정
+
+    // 3. 전송할 데이터를 객체 형태로 정의합니다.
+    const formData = {
+        boardSeq: boardSeq,
+        menuSeq: menuSeq,
+        conSeq: conSeq
+    };
+
+    // 4. formData 객체의 모든 키-값 쌍에 대해 <input> 엘리먼트를 생성하고 form에 추가합니다.
+    for (const key in formData) {
+        // 이 객체가 실제로 소유한 속성인지 확인합니다.
+        if (Object.prototype.hasOwnProperty.call(formData, key)) {
+            const dataInput = document.createElement('input');
+            dataInput.setAttribute('type', 'hidden');
+            dataInput.setAttribute('name', key); // name은 객체의 키(key)로 설정
+            dataInput.setAttribute('value', formData[key]); // value는 객체의 값(value)으로 설정
+            form.appendChild(dataInput);
+        }
+    }
+
+    // 5. 완성된 <form>을 현재 문서의 <body> 맨 끝에 추가합니다.
+    document.body.appendChild(form);
+
+    // 6. Form을 자동으로 제출합니다.
+    form.submit();
+
+    // 7. 제출 후, 원래 페이지에 남아있는 <form>을 삭제합니다.
+    document.body.removeChild(form);
+}

--- a/policy_recommend/url.js
+++ b/policy_recommend/url.js
@@ -1,5 +1,8 @@
+//        boardSeq, menuSeq
 // 기관소식: 47 7100
 // 타기관소식: 2 282
+
+// 실행시 링크 생성 후 새 창으로 이동
 function get_url(boardSeq=47, menuSeq=7100, conSeq=466575){
     // 1. <form> 엘리먼트를 동적으로 생성합니다.
     const form = document.createElement('form');
@@ -18,7 +21,6 @@ function get_url(boardSeq=47, menuSeq=7100, conSeq=466575){
 
     // 4. formData 객체의 모든 키-값 쌍에 대해 <input> 엘리먼트를 생성하고 form에 추가합니다.
     for (const key in formData) {
-        // 이 객체가 실제로 소유한 속성인지 확인합니다.
         if (Object.prototype.hasOwnProperty.call(formData, key)) {
             const dataInput = document.createElement('input');
             dataInput.setAttribute('type', 'hidden');
@@ -31,9 +33,7 @@ function get_url(boardSeq=47, menuSeq=7100, conSeq=466575){
     // 5. 완성된 <form>을 현재 문서의 <body> 맨 끝에 추가합니다.
     document.body.appendChild(form);
 
-    // 6. Form을 자동으로 제출합니다.
     form.submit();
 
-    // 7. 제출 후, 원래 페이지에 남아있는 <form>을 삭제합니다.
     document.body.removeChild(form);
 }


### PR DESCRIPTION
## 개요
정책 추천시 제공되는 목록에서 게시글 제목 클릭시 자동으로 해당 소개 링크로 넘어가기 위한 함수를 추가하였습니다.(url.js)
conSeq값을 불러와 새 창에서 사용자가 해당 게시물 사이트가 띄워져 볼 수 있습니다. (현재 conSeq값은 DB에 추가 되어있지 않음. 추후 추가 예정)


## PR 유형
어떤 변경 사항이 있나요?

- 정책 페이지 자동 제공 함수 추가

